### PR TITLE
Minor improvements of VSCode devcontainer

### DIFF
--- a/client-vscode-remote-container/.devcontainer/scripts/postCreate.sh
+++ b/client-vscode-remote-container/.devcontainer/scripts/postCreate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -o xtrace
 
-yarn install
+yarn install --network-timeout 1000000000
 
 [[ -f .devcontainer/scripts/dbinit.sh ]] && (
 	bash .devcontainer/scripts/dbinit.sh

--- a/client-vscode-remote-container/README.md
+++ b/client-vscode-remote-container/README.md
@@ -1,4 +1,4 @@
-# Contianer files for VS-Code Remote Editing
+# Container files for Visual Studio Code Remote Editing
 
 This folder contains anything you need to use Visual Studio Code's remote developing features to start developing on the Chemotion ELN inside a Docker development container.
 
@@ -7,36 +7,37 @@ Video Tutorial here: [YouTube](https://www.youtube.com/watch?v=HZCAbC6ldzE)
 ## Requirements
 
 -   Visual Studio Code (non-OSS version. Remote development is not supported by the open source builds.)
--   working Docker installation
--   the [Remote Developing extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) installed.
+-   Visual Studio Code's [Remote Developing extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)
+-   working [Docker installation](https://docs.docker.com/get-docker/)
 
-For more information check out [Microsoft's knowledge base](https://code.visualstudio.com/docs/remote/remote-overview) for more detailed information.
+For more detailed information check out [Microsoft's knowledge base](https://code.visualstudio.com/docs/remote/remote-overview).
 
 # General Information
 
-The purpose is to setup a VSCode remote development environment in a Docker container. See the knowledge base article above if all this does not sound familiar to you.
+The purpose is to set up a VSCode remote development environment in a Docker container. See the knowledge base article above if all this does not sound familiar to you.
 
 The setup is as follows:
 
-`.devcontainer/devcontainer.json` contains the definition of which Dockerfiles/docker-compose files to use and is read by VSCode. In addition it contains some postCreation command, that is run as soon as the container finished building. In our case this is:
+`.devcontainer/devcontainer.json` specifies which Dockerfiles/docker-compose files VSCode should use. In addition it contains a postCreation command, that is run as soon as the container finished building. In our case the postCreation command is:
 
 -   creating a database
 -   enabling all necessary extensions in the container (for VSCode) and for the database
 -   seeding the database
 
-The used Dockerfile to build an development environment is `Dockerfile.vscode`. The file is it's own documentation.
+The Dockerfile that is used to build the development environment is called `Dockerfile.vscode`. This file is it's own documentation.
 
-To start an additional container for a database server, `docker-compose.vscode` is used. Again, the file is pretty self-explainatory
+To start an additional container for a database server, `docker-compose.vscode` is used. Again, the file is pretty self-explainatory.
 
 # Usage
+:exclamation: **IMPORTANT**: make sure Docker is running before proceeding with the instructions below.
 
-> As of now, the script "createWorkspace.sh <someFolder>" will create a workspace for you in the folder specified.
+> As of now, the script `createWorkspace.sh <someFolder>` will create a workspace for you in the folder specified.
 > This includes cloning the chemotion source repository and copying all files where they belong.
 > This should be an easier alternative to the steps below.
 > **Optional:** download a suitable version of the file `gems.tar.gz` from [here](https://gems.ptrxyz.de/). It contains precompiled gems and
 > speeds up the whole building process by A LOT! Place it in the same folder as `createWorkspace.sh`.
 
-**Step 1:** First, check out the Chemotion ELN source from the [GitHub Repo](https://github.com/ComPlat/chemotion_ELN). In the following `/host/workspace/chemotion` will be used as the target directory:
+**Step 1:** First, check out the Chemotion ELN source from the [GitHub Repo](https://github.com/ComPlat/chemotion_ELN). In the following `/host/workspace/chemotion` will be used as the source directory:
 
 ```
 $ git clone https://github.com/ComPlat/chemotion_ELN /host/workspace/chemotion
@@ -58,13 +59,13 @@ Additionally rename `public/welcome-message-sample.md` to `public/welcome-messag
 $ cp -R .devcontainer /host/workspace/chemotion
 ```
 
-**Step 4:** create an empty folder for gems. This folder will be used as gem cache and speeds up the container building process in consecutive buildings:
+**Step 4:** create an empty folder for gems. This folder will be used as gem cache and speeds up the container building process for subsequent builds:
 
 ```
 $ mkdir -p /host/workspace/chemotion && chown 1000:1000 /host/workspace/chemotion
 ```
 
-Attention: make sure the folder is writeable by UID 1000 as shown in the snippet here.
+:exclamation: Attention: make sure the folder is writeable by UID 1000 as shown in the snippet above.
 
 **Step 5:** Open VSCode and open the Chemotion folder: `File` -> `Open Folder` -> select the right folder, here `/workspace/chemotion`.
 
@@ -72,7 +73,7 @@ Attention: make sure the folder is writeable by UID 1000 as shown in the snippet
 
 If the prompt does not show, install the extension pack as mentioned above. Then, you will find an icon similar to `><` in the very bottom left of VSCode's status bar. Click on it and select "Reopen in Container".
 
-**Step 6:** After the container is build, you will be able to access a terminal in the container using VSCode (`Terminal` -> `New Terminal`). If all steps were followed correclty, the container will already be initalised with seed data. This was done by the `postCreateCommand` in the `.devcontainer/devcontainer.json` file. See that file for how it is done.
+**Step 6:** After the container is build, you will be able to access a terminal in the container using VSCode (`Terminal` -> `New Terminal`). If all steps were followed correctly, the container will already be initalised with seed data. This was done by the `postCreateCommand` in the `.devcontainer/devcontainer.json` file. See that file for how it is done.
 
 **Step 7:** You are now ready to do some basic testing: run `bundle exec rails server` in the terminal and open the website in your browser (defaults to `localhost:3000`) when prompted. For the first time, this will take some time as sprites need to be generated and Javascripts need to be transpiled/bundled. You can now log in using the seeded admin user "ADM" with password "PleaseChangeYourPassword".
 
@@ -82,4 +83,4 @@ If the prompt does not show, install the extension pack as mentioned above. Then
 $ RAILS_ENV=test bundle exec rspec ./spec/features
 ```
 
-**Optional:** For a better development experience it's also recommended to install the `solargraph` and the `ruby-debug-ide` gems to enable language server and debugging support in VScode for Ruby. This can be done by executing `gem install solargraph ruby-debug-ide`
+**Optional:** For a better development experience it's recommended to also install the `solargraph` and the `ruby-debug-ide` gems to enable language server and debugging support in VScode for Ruby. This can be done by executing `gem install solargraph ruby-debug-ide`.

--- a/client-vscode-remote-container/createWorkspace.sh
+++ b/client-vscode-remote-container/createWorkspace.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-function confirm() {	
+function confirm() {
 	while : ; do
 		read -p "$1 (y/n)? " choice
 		case "$choice" in
@@ -66,19 +66,21 @@ if [[ -f gems.tar.gz ]]; then
 	# todo: explain why this is not default...
 	confirm "Embed gems and precompiled libraries (recommended)?" && {
 		echo "Info: precompiled libraries will be embedded."
-			
+
 		( a=$(pwd); cd ${dest}/.devcontainer && tar xfvz ${a}/gems.tar.gz )
 		sed -i '/^BUNDLED WITH$/!b;n;c\ \ \ 2.2.25' ${dest}/Gemfile.lock
-	
+
 		# This was the alternate approach. Probably will be removed in the future.
 		# cp rdkit_chem.tar.gz ${dest}/rdkit_chem.tar.gz
-		# sed -i "s#^gem 'rdkit_chem'.*#gem 'rdkit_chem', git: 'https://github.com/ptrxyz/rdkit_chem', ref: 'b7532a4bbbb154ed2bb7d49d15a79c26eb2c8086'#g" ${dest}/Gemfile	
+		# sed -i "s#^gem 'rdkit_chem'.*#gem 'rdkit_chem', git: 'https://github.com/ptrxyz/rdkit_chem', ref: 'b7532a4bbbb154ed2bb7d49d15a79c26eb2c8086'#g" ${dest}/Gemfile
 	} || {
 		echo "Info: precompiled libraries will be NOT embedded."
 		mkdir -p ${dest}/.devcontainer/gems
 		chown 1000:1000 ${dest}/.devcontainer/gems || echo "Warning: could not set permissions for gems volume!"
 	}
 else
+	mkdir -p ${dest}/.devcontainer/gems
+	chown 1000:1000 ${dest}/.devcontainer/gems || echo "Warning: could not set permissions for gems volume!"
 	echo "Info: precompiled libraries not found. skipping..."
 fi
 


### PR DESCRIPTION
I tested the VSCode devcontainer on WSL. Running `createWorkspace.sh` worked almost straight out of the box.

I had to make two minor adjustments in order to get the container to build properly on WSL on my machine. These adjustments are generic enough that they might be worth merging in order to make the experience of other users more seamless as well.

1. Commit 305179b52632d52566988272a516e15123579cc8 was necessary to prevent `yarn install` in `scripts/postCreate.sh` from failing with a timeout on a slow network.
2. Commit 455d9a543b3961a8715d71535df0cb4d0f2da5e3 was necessary to prevent `bundle install` in `scripts/postCreate.sh` from failing in the abscence of a writeable `gems` directory (I didn't use the pre-compiles gems).

The remaining commit ca1d268faef381eadc1000cc61c1243caa651944 contains only a few light edits of the README.