### PR TITLE
Adding a name for spectra volume

### DIFF
--- a/eln/fixes/99-megorei.patch
+++ b/eln/fixes/99-megorei.patch
@@ -1,0 +1,18 @@
+commit e60235201bd3e0787564c6c86b81766e064bcde4 (gitlab/megorei-biology, megorei-biology)
+Author: PiTrem <pierre.tremouilhac@kit.edu>
+Date:   Mon May 9 14:28:24 2022 +0000
+
+    fix typo
+
+diff --git a/app/packs/src/components/fetchers/MeasurementsFetcher.js b/app/packs/src/components/fetchers/MeasurementsFetcher.js
+index cf8c386a6..d85431f0b 100644
+--- a/app/packs/src/components/fetchers/MeasurementsFetcher.js
++++ b/app/packs/src/components/fetchers/MeasurementsFetcher.js
+@@ -1,5 +1,5 @@
+ import 'whatwg-fetch';
+-import Measurement from '../models/measurement';
++import Measurement from '../models/Measurement';
+ 
+ export default class MeasurementsFetcher {
+   static fetchMeasurementHierarchy(sample) {
+

--- a/testenv/docker-compose-production.yml
+++ b/testenv/docker-compose-production.yml
@@ -73,6 +73,7 @@ volumes:
     chemotion_db:
         name: chemotion_db
     spectra:
+        name: chemotion_spectra
 
 networks:
     chemotion:


### PR DESCRIPTION
To bring it in line with the remaining volume names. Since this Spectra volume is created to work alongside chemotion.