### PR TITLE
changed ubuntu from latest to focal

### DIFF
--- a/client-vscode-remote-container/.devcontainer/docker/Dockerfile
+++ b/client-vscode-remote-container/.devcontainer/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:focal
 
 # set timezone
 ENV TIMEZONE=Europe/Berlin

--- a/client-vscode-remote-container/.devcontainer/docker/docker-compose.yml
+++ b/client-vscode-remote-container/.devcontainer/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
             context: .
             dockerfile: Dockerfile
         depends_on:
-            - 'db'
+            - db
         environment:
             - RAILS_ENV=development
             - BUNDLE_JOBS=24


### PR DESCRIPTION
- latest now points to 2022 and the dockerfile is meant to work for ubuntu 2020 (because we ask for apt packages that are bound to 2020)
- this needs to be fixed as the vs-code dev container is the recommended way till the CLI-based dev environment comes along